### PR TITLE
Improve continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,4 +83,4 @@ jobs:
     steps:
       steps:
         - build_project:
-            project_name: zio-spark
+            project_name: "zio-spark"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,5 @@ jobs:
     <<: *environment
     working_directory: ~/repo
     steps:
-      steps:
-        - build_project:
-            project_name: "zio-spark"
+      - build_project:
+          project_name: "zio-spark"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ aliases:
 
   - &fmt_check
     name: "Check code format"
-    command: cat /dev/null | sbt check
+    command: cat /dev/null | sbt check "scalafix --check"
 
   - &configure_gpg
     name: configure GPG
@@ -52,7 +52,7 @@ commands:
       project_name:
         type: string
       extra_fs_deps:
-        default:  ""
+        default: ""
         type: string
     steps:
       - checkout
@@ -84,4 +84,3 @@ jobs:
       steps:
         - build_project:
             project_name: zio-spark
-  

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 target
 .idea
+
+project/metals.sbt
+project/project
+
+.metals
+.bloop
+.vscode

--- a/.mergify
+++ b/.mergify
@@ -1,0 +1,10 @@
+pull_request_rules:
+  - name: Automatic merge for scala steward 🐱
+    conditions:
+      - author=scala-steward
+      - "check-success=ci/circleci: build"
+    actions:
+      merge:
+        method: squash
+      label:
+        add: [dependency upgrade]

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,9 @@
+rules = [
+  DisableSyntax
+  ExplicitResultTypes
+  LeakingImplicitClassVal
+  NoAutoTupling
+  NoValInForComprehension
+  ProcedureSyntax
+  RemoveUnused
+]

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,7 +1,9 @@
 rules = [
+  Disable
   DisableSyntax
   ExplicitResultTypes
   LeakingImplicitClassVal
+  MissingFinal
   NoAutoTupling
   NoValInForComprehension
   OrganizeImports

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -4,6 +4,19 @@ rules = [
   LeakingImplicitClassVal
   NoAutoTupling
   NoValInForComprehension
+  OrganizeImports
   ProcedureSyntax
   RemoveUnused
 ]
+
+OrganizeImports {
+  expandRelative = true
+  groupedImports = Merge
+  groups = [
+    "zio.",
+    "zio.spark.",
+    "org.apache.spark.",
+    "*"
+  ]
+  removeUnused = true
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-Spark-ZIO
-======================
+# Spark-ZIO
 
+[![Circle CI](https://circleci.com/gh/univalence/zio-spark.svg?style=svg)](https://app.circleci.com/pipelines/github/univalence/zio-spark)
+[![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
 
 Spark-ZIO allows access to Spark using ZIO's environment.
 
@@ -8,14 +9,12 @@ Spark-ZIO allows access to Spark using ZIO's environment.
 
 If you want to get the very last version of this library you can still download it using bintray here : https://bintray.com/univalence/univalence-jvm/spark-zio
 
-
 ```scala
 resolvers += "zio-spark" at "http://dl.bintray.com/univalence/univalence-jvm"
 libraryDependencies += "io.univalence" %% "zio-spark" % "0.0.2"
 ```
 
 ## Roadmap
-
 
 ## License
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val libVersion =
     val zio              = "1.0.0-RC20"
     val scala2_12        = "2.12.11"
     val organize_imports = "0.4.4"
+    val scaluzzi         = "0.1.16"
   }
 
 scmInfo := Some(
@@ -146,6 +147,9 @@ inThisBuild(
     },
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
-    scalafixDependencies += "com.github.liancheng" %% "organize-imports" % libVersion.organize_imports
+    scalafixDependencies ++= Seq(
+      "com.github.liancheng" %% "organize-imports" % libVersion.organize_imports,
+      "com.github.vovapolu"  %% "scaluzzi"         % libVersion.scaluzzi
+    )
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,9 @@ import sbtdynver.GitCommitSuffix
 
 val libVersion =
   new {
-    val zio       = "1.0.0-RC20"
-    val scala2_12 = "2.12.11"
+    val zio              = "1.0.0-RC20"
+    val scala2_12        = "2.12.11"
+    val organize_imports = "0.4.4"
   }
 
 scmInfo := Some(
@@ -144,6 +145,7 @@ inThisBuild(
       sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
     },
     semanticdbEnabled := true,
-    semanticdbVersion := scalafixSemanticdb.revision
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalafixDependencies += "com.github.liancheng" %% "organize-imports" % libVersion.organize_imports
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,8 @@ inThisBuild(
     dynver := {
       val d = new java.util.Date
       sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
-    }
+    },
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision
   )
 )

--- a/src/main/scala/zio/spark/CircuitTap.scala
+++ b/src/main/scala/zio/spark/CircuitTap.scala
@@ -85,13 +85,13 @@ object Ratio {
 
 }
 
-case class DecayingRatio(ratio: Ratio, scale: Int) {
+final case class DecayingRatio(ratio: Ratio, scale: Int) {
   def decay(value: Ratio, maxScale: Long): DecayingRatio =
     DecayingRatio(Ratio.mean(scale, ratio)(1, value), if (scale < maxScale) scale else maxScale.toInt)
 }
 
 object CircuitTap {
-  private[spark] case class State(failed: Long, success: Long, rejected: Long, decayingErrorRatio: DecayingRatio) {
+  final private[spark] case class State(failed: Long, success: Long, rejected: Long, decayingErrorRatio: DecayingRatio) {
 
     def nextErrorRatio(ratio: Ratio): DecayingRatio =
       if (total == 0) DecayingRatio(ratio, decayingErrorRatio.scale)

--- a/src/main/scala/zio/spark/PackageSyntax.scala
+++ b/src/main/scala/zio/spark/PackageSyntax.scala
@@ -1,8 +1,10 @@
 package zio.spark
 
-import org.apache.spark.sql.{ DataFrameReader, SparkSession }
-import zio.spark.wrap.{ Clean, Impure, ImpureF }
 import zio.{ RIO, Task, ZIO, ZLayer }
+
+import zio.spark.wrap.{ Clean, Impure, ImpureF }
+
+import org.apache.spark.sql.{ DataFrameReader, SparkSession }
 
 trait PackageSyntax {
 

--- a/src/main/scala/zio/spark/ZSpark.scala
+++ b/src/main/scala/zio/spark/ZSpark.scala
@@ -1,10 +1,12 @@
 package zio.spark
 
+import zio.{ RIO, Task, UIO }
+
+import zio.spark.wrap.{ Clean, Impure, ImpureF }
+
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.{ PairRDDFunctions, RDD }
 import org.apache.spark.sql._
-import zio.spark.wrap.{ Clean, Impure, ImpureF }
-import zio.{ RIO, Task, UIO }
 
 import scala.reflect.ClassTag
 import scala.util.Try

--- a/src/main/scala/zio/spark/ZSpark.scala
+++ b/src/main/scala/zio/spark/ZSpark.scala
@@ -118,7 +118,7 @@ final class ZDataset[T](dataset: Dataset[T]) extends ZDataX(dataset) {
   def flatMap[B: Encoder](f: T => Seq[B]): ZDataset[B] = nowTotal(_.flatMap(f))
 }
 
-case class ZRelationalGroupedDataset(relationalGroupedDataset: RelationalGroupedDataset)
+final case class ZRelationalGroupedDataset(relationalGroupedDataset: RelationalGroupedDataset)
     extends Impure(relationalGroupedDataset) {
   def count: ZDataFrame = nowTotal(_.count())
 }

--- a/src/main/scala/zio/spark/implicits.scala
+++ b/src/main/scala/zio/spark/implicits.scala
@@ -1,8 +1,10 @@
 package zio.spark
 
-import org.apache.spark.sql.{ ColumnName, Encoder, Encoders }
 import zio.{ Task, ZIO }
+
 import zio.spark.wrap.Impure
+
+import org.apache.spark.sql.{ ColumnName, Encoder, Encoders }
 
 import scala.util.Try
 

--- a/src/main/scala/zio/spark/wrap/Clean.scala
+++ b/src/main/scala/zio/spark/wrap/Clean.scala
@@ -1,11 +1,13 @@
 package zio.spark.wrap
 
+import zio._
+
+import zio.spark._
+import zio.spark.wrap.Clean.Aux
+
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import zio._
-import zio.spark._
-import zio.spark.wrap.Clean.Aux
 
 import scala.util.Try
 


### PR DESCRIPTION
I put here several ideas to improve continuous integration of `zio-spark`, will change this PR according to your choices:
- Enable scalafix using the same configuration as [zio](https://github.com/zio/zio/blob/master/.scalafix.conf) => [organize-import](https://github.com/liancheng/scalafix-organize-imports#sbt) could be a good lib too, tell me if you want me to add it in the PR.
- [Scala Steward](https://github.com/scala-steward-org/scala-steward) also can help zio-spark to upgrade dependencies. Just add this repository inside [this file](https://github.com/scala-steward-org/repos/blob/master/repos-github.md). That's also a good idea to add a mergify rule for scala steward to automerge his own PR using this kind of configuration: ([1](https://github.com/dylandoamaral/zinteract/blob/master/.mergify.yml), [2](https://github.com/zio/zio/blob/master/.mergify.yml)).
- Add badges to the readme for coverage, integration etc.

Have a nice ziohackathon !