### PR TITLE
feat: add zio spark test assertion system

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,6 +141,8 @@ lazy val test =
   (project in file("zio-spark-test"))
     .settings(crossScalaVersionSettings)
     .settings(commonSettings)
+    .settings(macroExpansionSettings)
+    .settings(macroDefinitionSettings)
     .settings(
       name := "zio-spark-test",
       scalaMajorVersion := CrossVersion.partialVersion(scalaVersion.value).get._1,
@@ -315,4 +317,33 @@ lazy val noPublishingSettings = Seq(
   // Don't generate documentation for the examples
   Compile / doc / sources := Seq.empty,
   Compile / packageDoc / publishArtifact := false
+)
+
+def macroExpansionSettings = Seq(
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 13)) => Seq("-Ymacro-annotations")
+      case _ => Seq.empty
+    }
+  },
+  libraryDependencies ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, x)) if x <= 12 =>
+        Seq(compilerPlugin(("org.scalamacros" % "paradise" % "2.1.1").cross(CrossVersion.full)))
+      case _ => Seq.empty
+    }
+  }
+)
+
+def macroDefinitionSettings = Seq(
+  scalacOptions += "-language:experimental.macros",
+  libraryDependencies ++= {
+    CrossVersion.partialVersion(scalaVersion.value).get._1 match {
+      case 3 => Seq.empty
+      case _ => Seq(
+        "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
+      )
+    }
+  }
 )

--- a/zio-spark-test/src/main/scala-2/zio/spark/test/Macros.scala
+++ b/zio-spark-test/src/main/scala-2/zio/spark/test/Macros.scala
@@ -1,0 +1,41 @@
+package zio.spark.test
+
+import scala.reflect.macros._
+
+private[test] object Macros {
+
+  // Pilfered (with immense gratitude & minor modifications)
+  // from https://github.com/zio/zio/blob/series/2.x/test/shared/src/main/scala-2/zio/test/Macros.scala
+  def assert_impl(c: blackbox.Context)(value: c.Tree)(assertion: c.Tree): c.Tree = {
+    import c.universe._
+
+    // Pilfered (with immense gratitude & minor modifications)
+    // from https://github.com/com-lihaoyi/sourcecode
+    def text[T: c.WeakTypeTag](tree: c.Tree): (Int, Int, String) = {
+      val fileContent = new String(tree.pos.source.content)
+      var start = tree.collect { case treeVal =>
+        treeVal.pos match {
+          case NoPosition => Int.MaxValue
+          case p => p.start
+        }
+      }.min
+      val initialStart = start
+
+      // Moves to the true beginning of the expression, in the case where the
+      // internal expression is wrapped in parens.
+      while ((start - 2) >= 0 && fileContent(start - 2) == '(') {
+        start -= 1
+      }
+
+      val g = c.asInstanceOf[reflect.macros.runtime.Context].global
+      val parser = g.newUnitParser(fileContent.drop(start))
+      parser.expr()
+      val end = parser.in.lastOffset
+      (initialStart - start, start, fileContent.slice(start, start + end))
+    }
+
+    val codeString = text(value)._3
+    val assertionString = text(assertion)._3
+    q"_root_.zio.spark.test.assertZIOSparkImpl($value, $codeString, $assertionString)($assertion)"
+  }
+}

--- a/zio-spark-test/src/main/scala-3/zio/spark/test/Macros.scala
+++ b/zio-spark-test/src/main/scala-3/zio/spark/test/Macros.scala
@@ -1,0 +1,41 @@
+package zio.spark.test
+
+import scala.reflect.macros._
+
+private[test] object Macros {
+
+  // Pilfered (with immense gratitude & minor modifications)
+  // from https://github.com/zio/zio/blob/series/2.x/test/shared/src/main/scala-2/zio/test/Macros.scala
+  def assert_impl(c: blackbox.Context)(expr: c.Tree)(assertion: c.Tree): c.Tree = {
+    import c.universe._
+
+    // Pilfered (with immense gratitude & minor modifications)
+    // from https://github.com/com-lihaoyi/sourcecode
+    def text[T: c.WeakTypeTag](tree: c.Tree): (Int, Int, String) = {
+      val fileContent = new String(tree.pos.source.content)
+      var start = tree.collect { case treeVal =>
+        treeVal.pos match {
+          case NoPosition => Int.MaxValue
+          case p => p.start
+        }
+      }.min
+      val initialStart = start
+
+      // Moves to the true beginning of the expression, in the case where the
+      // internal expression is wrapped in parens.
+      while ((start - 2) >= 0 && fileContent(start - 2) == '(') {
+        start -= 1
+      }
+
+      val g = c.asInstanceOf[reflect.macros.runtime.Context].global
+      val parser = g.newUnitParser(fileContent.drop(start))
+      parser.expr()
+      val end = parser.in.lastOffset
+      (initialStart - start, start, fileContent.slice(start, start + end))
+    }
+
+    val codeString = text(expr)._3
+    val assertionString = text(assertion)._3
+    q"_root_.zio.spark.test.CompileVariants.newAssertProxy($expr, $codeString, $assertionString)($assertion)"
+  }
+}

--- a/zio-spark-test/src/main/scala/zio/spark/test/SparkAssertion.scala
+++ b/zio-spark-test/src/main/scala/zio/spark/test/SparkAssertion.scala
@@ -1,0 +1,29 @@
+package zio.spark.test
+
+import zio.internal.stacktracer.SourceLocation
+import zio.spark.sql.{Dataset, SIO}
+import zio.test.{Assertion, TestArrow, TestResult}
+import zio.internal.ansi.AnsiStringOps
+final case class SparkAssertion[A, B](f: A => SIO[B], assertion: Assertion[B])
+
+object SparkAssertion {
+  private[test] def smartAssert[A](
+    expr: => A,
+    codePart: String,
+    assertionPart: String
+  )(
+    assertion: Assertion[A]
+  )(implicit sourceLocation: SourceLocation): TestResult = {
+    lazy val value0 = expr
+    val completeString = codePart.blue + " did not satisfy " + assertionPart.cyan
+
+    TestResult(
+      (TestArrow.succeed(value0).withCode(codePart) >>> assertion.arrow)
+        .withLocation
+        .withCompleteCode(completeString)
+    )
+  }
+
+  def isEmpty[A]: SparkAssertion[Dataset[A], Boolean] =
+    SparkAssertion(_.isEmpty, Assertion.isTrue.label("Dataset was not empty"))
+}

--- a/zio-spark-test/src/main/scala/zio/spark/test/package.scala
+++ b/zio-spark-test/src/main/scala/zio/spark/test/package.scala
@@ -2,11 +2,13 @@ package zio.spark
 
 import org.apache.spark.sql.Encoder
 
-import zio.Trace
+import zio._
+import zio.internal.stacktracer.SourceLocation
 import zio.spark.parameter._
 import zio.spark.rdd.RDD
 import zio.spark.sql._
 import zio.spark.sql.implicits._
+import zio.test.{assert, TestResult}
 
 import scala.reflect.ClassTag
 
@@ -20,4 +22,19 @@ package object test {
   def Dataset[T: Encoder](values: T*)(implicit trace: Trace): SIO[Dataset[T]] = values.toDataset
 
   def RDD[T: ClassTag](values: T*)(implicit trace: Trace): SIO[RDD[T]] = values.toRDD
+
+  private[test] def assertZIOSparkImpl[A, B](value: SIO[A], codePart: String,
+                                             assertionPart: String)(assertion: SparkAssertion[A, B])(implicit
+                                                                           trace: Trace,
+                                                                           sourceLocation: SourceLocation
+  ) = {
+    value.flatMap(assertion.f).map { a => SparkAssertion.smartAssert(a, codePart, assertionPart)(assertion.assertion)}
+  }
+
+  // TODO
+  def assertSpark[A, B](value: A)(assertion: SparkAssertion[A, B]): SIO[TestResult] = ???
+    //assertZIOSpark(ZIO.succeed(value))(assertion)
+
+  def assertZIOSpark[A, B](value: SIO[A])(assertion: SparkAssertion[A, B]): SIO[TestResult] =
+    macro Macros.assert_impl
 }

--- a/zio-spark-test/src/test/scala/zio/spark/test/ZIOSparkSpecDefaultSpec.scala
+++ b/zio-spark-test/src/test/scala/zio/spark/test/ZIOSparkSpecDefaultSpec.scala
@@ -3,22 +3,45 @@ package zio.spark.test
 import scala3encoders.given // scalafix:ok
 
 import zio.spark.sql.implicits._
+import zio.spark.test.SparkAssertion._
 import zio.test._
 
+/**
+ * What we have :
+ * Assertion failed:
+  ✗ false was not true
+  Dataset was not empty
+  Dataset(1, 2, 3) did not satisfy isEmpty
+  Dataset(1, 2, 3) = false
+  at ...
+ */
+
+/**
+ * What we want :
+ * Assertion failed:
+  ✗ Dataset was not empty
+  Dataset(1, 2, 3) did not satisfy isEmpty
+  Dataset(1, 2, 3).isEmpty = false
+  at ...
+ */
+
+/**
+ * Assertion failed: ✗ 3 was not equal to 2 count did not satisfy
+ * Assertion.equalTo(2L) => dataset did not satisfy isEmpty count = 3
+ * check
+ */
 object ZIOSparkSpecDefaultSpec extends ZIOSparkSpecDefault {
+  Assertion
   override def sparkSpec =
     suite("ZIOSparkSpecDefault can run spark job without providing layer")(
       test("It can run Dataset job") {
-        for {
-          df    <- Dataset(1, 2, 3)
-          count <- df.count
-        } yield assertTrue(count == 3L)
+        assertZIOSpark(Dataset(1, 2, 3))(isEmpty)
       },
       test("It can run RDD job") {
         for {
-          rdd   <- RDD(1, 2, 3)
-          count <- rdd.count
-        } yield assertTrue(count == 3L)
+          rdd <- RDD(1, 2, 3)
+          res <- assertZIO(rdd.count)(Assertion.equalTo(2L))
+        } yield res
       }
     )
 }


### PR DESCRIPTION
Here is the missing step for now :
- [X] Create a way to simply create spark macros close to ZIO way of doing tests
- [ ] Validate the design 
- [ ] Add macro for `assertSpark`
- [ ] Modify macro to get a better output message