### PR TITLE
Fix #381: add ZIOSparkApp

### DIFF
--- a/examples/simple-app/src/main/scala/example/SimpleApp.scala
+++ b/examples/simple-app/src/main/scala/example/SimpleApp.scala
@@ -4,12 +4,12 @@ import org.apache.spark.sql.Row
 
 import zio._
 import zio.spark.experimental
-import zio.spark.experimental.Pipeline
+import zio.spark.experimental.{Pipeline, ZIOSparkAppDefault}
 import zio.spark.parameter._
 import zio.spark.sql._
 import zio.spark.sql.implicits._
 
-object SimpleApp extends ZIOAppDefault {
+object SimpleApp extends ZIOSparkAppDefault {
 
   import zio.spark.sql.TryAnalysis.syntax.throwAnalysisException
 

--- a/examples/spark-code-migration/src/main/scala/example/SparkCodeMigration.scala
+++ b/examples/spark-code-migration/src/main/scala/example/SparkCodeMigration.scala
@@ -1,10 +1,11 @@
 package example
 
 import zio._
+import zio.spark.experimental.ZIOSparkAppDefault
 import zio.spark.parameter._
 import zio.spark.sql._
 
-object SparkCodeMigration extends ZIOAppDefault {
+object SparkCodeMigration extends ZIOSparkAppDefault {
   val NUM_SAMPLES: Int = 100000
 
   val computePiJob: SIO[Long] =

--- a/examples/using-older-spark-version/src/main/scala/example/UsingOlderSparkVersion.scala
+++ b/examples/using-older-spark-version/src/main/scala/example/UsingOlderSparkVersion.scala
@@ -4,12 +4,12 @@ import org.apache.spark.sql.Row
 
 import zio._
 import zio.spark.experimental
-import zio.spark.experimental.Pipeline
+import zio.spark.experimental.{Pipeline, ZIOSparkAppDefault}
 import zio.spark.parameter._
 import zio.spark.sql._
 import zio.spark.sql.implicits._
 
-object UsingOlderSparkVersion extends ZIOAppDefault {
+object UsingOlderSparkVersion extends ZIOSparkAppDefault {
 
   import zio.spark.sql.TryAnalysis.syntax.throwAnalysisException
 

--- a/examples/word-count/src/main/scala/example/WordCount.scala
+++ b/examples/word-count/src/main/scala/example/WordCount.scala
@@ -1,12 +1,13 @@
 package example
 
 import zio._
+import zio.spark.experimental.ZIOSparkAppDefault
 import zio.spark.parameter._
 import zio.spark.rdd._
 import zio.spark.sql._
 import zio.spark.sql.implicits._
 
-object WordCount extends ZIOAppDefault {
+object WordCount extends ZIOSparkAppDefault {
 
   val filePath: String = "build.sbt"
 

--- a/examples/zio-ecosystem/src/main/scala/example/ZIOEcosystem.scala
+++ b/examples/zio-ecosystem/src/main/scala/example/ZIOEcosystem.scala
@@ -8,10 +8,11 @@ import org.apache.log4j.{Level, Logger}
 import zio._
 import zio.cli.{Args, CliApp, Command, Options}
 import zio.cli.HelpDoc.Span.text
+import zio.spark.experimental.ZIOSparkAppDefault
 import zio.spark.parameter._
 import zio.spark.sql._
 
-object ZIOEcosystem extends ZIOAppDefault {
+object ZIOEcosystem extends ZIOSparkAppDefault {
   // A more sophisticated layer to add middleware logs
   private val session: ZLayer[Any, Throwable, SparkSession] =
     ZLayer.scoped {

--- a/zio-spark-core/src/main/scala/zio/spark/experimental/ZIOSparkApp.scala
+++ b/zio-spark-core/src/main/scala/zio/spark/experimental/ZIOSparkApp.scala
@@ -1,0 +1,44 @@
+package zio.spark.experimental
+
+import zio._
+
+trait ZIOSparkApp extends ZIOAppVersionSpecific {
+  type Environment
+
+  val bootstrap: ZLayer[ZIOAppArgs, Any, Environment]
+
+  def run: ZIO[Environment with ZIOAppArgs with Scope, Any, Any]
+
+  def runtime: Runtime[Any] = Runtime.default
+
+  final def main(args0: Array[String]): Unit = {
+    implicit val trace: Trace = Trace.empty
+
+    val newLayer =
+      ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>> bootstrap +!+ ZLayer.environment[ZIOAppArgs]
+
+    val workflow =
+      (for {
+        runtime <- ZIO.runtime[Environment with ZIOAppArgs]
+        result  <- runtime.run(ZIO.scoped[Environment with ZIOAppArgs](run)).tapErrorCause(ZIO.logErrorCause(_))
+      } yield result).provideLayer(newLayer.tapErrorCause(ZIO.logErrorCause(_)))
+
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe
+        .run {
+          for {
+            fiberId <- ZIO.fiberId
+            fiber   <- workflow.ensuring(interruptRootFibers(fiberId)).fork
+            _       <- fiber.join
+          } yield ()
+        }
+        .getOrThrowFiberFailure()
+    }
+  }
+
+  private def interruptRootFibers(fiberId: FiberId)(implicit trace: Trace): UIO[Unit] =
+    for {
+      roots <- Fiber.roots
+      _     <- Fiber.interruptAll(roots.view.filterNot(_.id == fiberId))
+    } yield ()
+}

--- a/zio-spark-core/src/main/scala/zio/spark/experimental/ZIOSparkAppDefault.scala
+++ b/zio-spark-core/src/main/scala/zio/spark/experimental/ZIOSparkAppDefault.scala
@@ -1,0 +1,9 @@
+package zio.spark.experimental
+
+import zio._
+
+trait ZIOSparkAppDefault extends ZIOSparkApp {
+  type Environment = Any
+
+  val bootstrap: ZLayer[ZIOAppArgs, Any, Any] = ZLayer.empty
+}


### PR DESCRIPTION
Here is the `ZIOSparkApp` (and `ZIOSparkAppDefault`) I've been using. I also changed the examples to extend it – I'm not sure if that's necessary. I didn't know where exactly to add it in the code, so I've put it in "experimental" for now.

I'm not sure if the `interruptRootFibers` function is necessary, but I have left it in from ZIO's `ZIOApp`.

ZIO'S `ZIOApp` also handles catastrophic failures [here](https://github.com/zio/zio/blob/series/2.x/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala#L39C21-L39C21), but I couldn't access those functions as they are private.

I can't really think of a way to test this class. A test to ensure it works with Yarn would make sure the `System.exit` function is never called. I suppose I could write a test that calls `ZIOSparkApp.main` and ensures the system hasn't exited (by simply continuing...); otherwise I'm not sure.